### PR TITLE
Update Map.cpp to accept larger maps

### DIFF
--- a/BirchEngine/Src/Map.cpp
+++ b/BirchEngine/Src/Map.cpp
@@ -19,20 +19,20 @@ void Map::LoadMap(std::string path, int sizeX, int sizeY)
 {
 	char c;
 	std::fstream mapFile;
+        std::string str;
 	mapFile.open(path);
-
-	int srcX, srcY;
 
 	for (int y = 0; y < sizeY; y++)
 	{
 		for (int x = 0; x < sizeX; x++)
 		{
-			mapFile.get(c);
-			srcY = atoi(&c) * tileSize;
-			mapFile.get(c);
-			srcX = atoi(&c) * tileSize;
+			//It's y, x. so 13 is y=1, x=3
+			getline(mapFile, str, ',');
+			int srcIndex = stoi(str);
+			int srcY = (srcIndex / 10) * tileSize;
+			int srcX = (srcIndex % 10) * tileSize;
 			AddTile(srcX, srcY, x * scaledSize, y * scaledSize);
-			mapFile.ignore();
+			mapFile.ignore()
 		}
 	}
 


### PR DESCRIPTION
Change the for-loop to accept integers larger than two characters. Currently, if you have more than 99 unique tiles, the map parser won't handle that with `mapFile.get(c)` twice. With this new method, we're getting all integers at once and dealing with it from there.

Also, you probably will need to change your .map file. Here's an example of what your row should look like:

`00 , 00 , 00 , 10 , 11 , 12 , 13 , 14 , 15 , 16 , 17 , 18 , 19 , 20 , 00 , 00 ,`